### PR TITLE
增加对STD_1_0以及之前的格式支持

### DIFF
--- a/Core/lpk_loader.py
+++ b/Core/lpk_loader.py
@@ -13,7 +13,7 @@ class LpkLoader():
         self.lpkpath = lpkpath
         self.configpath = configpath
         self.lpkType = None
-        self.encrypted = True
+        self.encrypted = "true"
         self.trans = {}
         self.entrys = {}
         self.load_lpk()
@@ -62,8 +62,8 @@ class LpkLoader():
             try:
                 print("Deprecated/unknown lpk format detected. Attempting with STD_1_0 format...")
                 print("Decryption may not work for some packs, even though this script outputs all files.")
-                self.encrypted = self.mlve_config.get("encrypt", True)
-                if not self.encrypted:
+                self.encrypted = self.mlve_config.get("encrypt", "true")
+                if self.encrypted == "false":
                     print("lpk is not encrypted, extracting all files...")
                     self.lpkfile.extractall(outputdir)
                     return

--- a/Core/lpk_loader.py
+++ b/Core/lpk_loader.py
@@ -23,12 +23,11 @@ class LpkLoader():
         try:
             config_mlve_raw = self.lpkfile.read(hashed_filename("config.mlve")).decode()
         except KeyError:
-            pass
-        try:
-            config_mlve_raw = self.lpkfile.read("config.mlve").decode('utf-8-sig')
-        except:
-            logger.fatal("Failed to retrieve lpk config!")
-            exit(0)
+            try:
+                config_mlve_raw = self.lpkfile.read("config.mlve").decode('utf-8-sig')
+            except:
+                logger.fatal("Failed to retrieve lpk config!")
+                exit(0)
 
 
         self.mlve_config = json.loads(config_mlve_raw)

--- a/Core/lpk_loader.py
+++ b/Core/lpk_loader.py
@@ -201,9 +201,9 @@ class LpkLoader():
         elif self.lpkType == "STD_1_0":
             return genkey(self.mlve_config["id"] + file)
         else:
-            return genkey("com.oukaitou.live2d.pro" + self.mlve_config["id"] + "cDaNJnUazx2B4xCYFnAPiYSyd2M=\n")
+            #return genkey("com.oukaitou.live2d.pro" + self.mlve_config["id"] + "cDaNJnUazx2B4xCYFnAPiYSyd2M=\n")
         #else:
-            #raise Exception(f"not support type {self.mlve_config['type']}")
+            raise Exception(f"not support type {self.mlve_config['type']}")
 
     def decrypt_file(self, filename) -> bytes:
         data = self.lpkfile.read(filename)

--- a/Core/utils.py
+++ b/Core/utils.py
@@ -12,7 +12,7 @@ def hashed_filename(s: str) -> str:
 
 def safe_mkdir(s: str):
     try:
-        os.mkdir(s)
+        os.makedirs(s)
     except FileExistsError:
         pass
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This tool is designed to extract resources from Live2dExViewer's LPK files.
 
 If you encounter any issues while running this program, please consult the '[Issues](https://github.com/ihopenot/LpkUnpacker/issues)' section first.
 
+*Added support for (pre-)STD_1_0 formats.
+However, not all packs can be decrypted due to an unknown keygen/decryption algorithm.
 ## Requirements
 `python -m pip install -r requirements.txt`
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -5,6 +5,8 @@
 
 如果你在使用工具时遇到任何困难，请先查询'[Issues](https://github.com/ihopenot/LpkUnpacker/issues)'中的内容
 
+*增加了对STD_1_0以及之前的格式支持
+注意，少部分的早期lpk仍然无法解包，推测可能存在未知的密钥生成或解密算法
 ## 系统需求
 安装依赖：
 


### PR DESCRIPTION
STD_1_0及之前的格式有完整的文件目录结构，STD_1_0的密钥和解密算法和最新版本相同。更早的格式有略微不同的密钥生成方法。

STD_1_0之前的lpk配置文件格式比较混乱。经过测试，一些类似“ID00002001.lpk”的加密包仍然无法正确解密，可能是有不同的密钥生成/解密算法。